### PR TITLE
Bug fix and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ jobs:
       with:
         enabled-static-website: 'true'
         folder: 'MyFolder'
+        index-document: 'index.html'
+        error-document: '404.html' # For Angular apps with routing enabled, this must point to the index.html file because the requested routes don't exist phyiscally and blob storage would throw a 404.
         connection-string: ${{ secrets.CONNECTION_STRING }}
 
 ```

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const main = async () => {
     const containerName = core.getInput('blob-container-name');
     const accessPolicy = core.getInput('public-access-policy');
     const enableStaticWebSite = core.getInput('enabled-static-website');
+    const indexDoc = core.getInput('index-document');
+    const errorDoc = core.getInput('error-document');
 
     let args = ['run', '-c', 'Release', '--project', __dirname + '/src/AzureStorageAction/AzureStorageAction.csproj', '--'];
 
@@ -33,6 +35,16 @@ const main = async () => {
     if (enableStaticWebSite) {
         args.push('-s')
         args.push(enableStaticWebSite)
+    }
+
+    if(indexDoc) {
+        args.push('-i')
+        args.push(indexDoc)
+    }
+
+    if(errorDoc) {
+        args.push('-e')
+        args.push(errorDoc)
     }
 
     await exec.exec('dotnet', args);

--- a/src/AzureStorageAction.Test/Extensions/BlobServicePropertiesExtension/EnableStaticWebSite/EnableStaticWebSiteTest.cs
+++ b/src/AzureStorageAction.Test/Extensions/BlobServicePropertiesExtension/EnableStaticWebSite/EnableStaticWebSiteTest.cs
@@ -22,17 +22,17 @@ namespace AzureStorageAction.Test.Extensions.BlobServicePropertiesExtension.Enab
         [Test]
         public void EnableStaticWebSite_With_True_Return_True()
         {
-            blobServiceProperties.EnableStaticWebSite(true);
+            blobServiceProperties.EnableStaticWebSite("index.html", "404.html");
 
-            Assert.AreEqual(AzureStorageAction.Extensions.BlobServicePropertiesExtension.INDEXDOCUMENT, blobServiceProperties.StaticWebsite.IndexDocument);
-            Assert.AreEqual(AzureStorageAction.Extensions.BlobServicePropertiesExtension.ERRORDOCUMENT404PATH, blobServiceProperties.StaticWebsite.ErrorDocument404Path);
+            Assert.AreEqual("index.html", blobServiceProperties.StaticWebsite.IndexDocument);
+            Assert.AreEqual("404.html", blobServiceProperties.StaticWebsite.ErrorDocument404Path);
             Assert.IsTrue(blobServiceProperties.StaticWebsite.Enabled);
         }
 
         [Test]
         public void EnableStaticWebSite_With_False_Return_False()
         {
-            blobServiceProperties.EnableStaticWebSite(false);
+            blobServiceProperties.DisableStaticWebSite();
 
             Assert.IsFalse(blobServiceProperties.StaticWebsite.Enabled);
         }

--- a/src/AzureStorageAction/Arguments/ArgumentEnum.cs
+++ b/src/AzureStorageAction/Arguments/ArgumentEnum.cs
@@ -15,6 +15,12 @@
         PublicAccessPolicy,
 
         [Argument("-s", false)]
-        EnableStaticWebSite
+        EnableStaticWebSite,
+
+        [Argument("-i", false)]
+        IndexDocument,
+
+        [Argument("-e", false)]
+        ErrorDocument,
     }
 }

--- a/src/AzureStorageAction/BlobCommands/Commands/EnabledStaticWebSiteCommand.cs
+++ b/src/AzureStorageAction/BlobCommands/Commands/EnabledStaticWebSiteCommand.cs
@@ -18,7 +18,27 @@ namespace AzureStorageAction.BlobCommands.Commands
             {
                 Azure.Response<BlobServiceProperties> response = await BlobServiceClientSingleton.Instance.GetBlobServiceClient().GetPropertiesAsync();
                 BlobServiceProperties properties = response.Value;
-                properties.EnableStaticWebSite(enabled);
+                if(enabled)
+                {
+                    var indexDocument = ArgumentContext.Instance.GetValue(ArgumentEnum.IndexDocument);
+                    var errorDocument = ArgumentContext.Instance.GetValue(ArgumentEnum.ErrorDocument);
+
+                    if(string.IsNullOrWhiteSpace(indexDocument))
+                    {
+                        indexDocument = "index.html";
+                    }
+
+                    if(string.IsNullOrWhiteSpace(errorDocument))
+                    {
+                        indexDocument = "404.html";
+                    }
+
+                    properties.EnableStaticWebSite(indexDocument, errorDocument);
+                }
+                else
+                {
+                    properties.DisableStaticWebSite();
+                }
 
                 await BlobServiceClientSingleton.Instance.GetBlobServiceClient().SetPropertiesAsync(properties);
 
@@ -27,12 +47,12 @@ namespace AzureStorageAction.BlobCommands.Commands
                 if (enabled)
                 {
                     Console.WriteLine("Enabled Static Web Site:");
-                    Console.WriteLine($"IndexDocument: {properties.StaticWebsite.IndexDocument}");
-                    Console.WriteLine($"ErrorDocument404Path: {properties.StaticWebsite.ErrorDocument404Path}");
+                    Console.WriteLine($"  IndexDocument: {properties.StaticWebsite.IndexDocument}");
+                    Console.WriteLine($"  ErrorDocument404Path: {properties.StaticWebsite.ErrorDocument404Path}");
                 }
                 else
                 {
-                    Console.WriteLine("Disabled Static Web Site:");
+                    Console.WriteLine("Disabled Static Web Site.");
                 }
 
                 Console.WriteLine("***");

--- a/src/AzureStorageAction/Extensions/BlobServicePropertiesExtension.cs
+++ b/src/AzureStorageAction/Extensions/BlobServicePropertiesExtension.cs
@@ -4,16 +4,19 @@ namespace AzureStorageAction.Extensions
 {
     public static class BlobServicePropertiesExtension
     {
-        public const string INDEXDOCUMENT = "index.html";
-        public const string ERRORDOCUMENT404PATH = "404.html";
-        public static void EnableStaticWebSite(this BlobServiceProperties properies, bool enable)
+        public static void EnableStaticWebSite(this BlobServiceProperties properties, string indexDocument, string errorDocument)
         {
-            properies.StaticWebsite.Enabled = enable;
-            if (enable)
-            {
-                properies.StaticWebsite.ErrorDocument404Path = ERRORDOCUMENT404PATH;
-                properies.StaticWebsite.IndexDocument = INDEXDOCUMENT;
-            }
+            properties.StaticWebsite.Enabled = true;
+            properties.StaticWebsite.ErrorDocument404Path = errorDocument;
+            properties.StaticWebsite.IndexDocument = indexDocument;
+        }
+
+        public static void DisableStaticWebSite(this BlobServiceProperties properties)
+        {
+            properties.StaticWebsite.Enabled = false;
+            // Avoid error "Element IndexDocument is only expected when StaticWebsite/Enabled is enabled."
+            properties.StaticWebsite.ErrorDocument404Path = null;
+            properties.StaticWebsite.IndexDocument = null;
         }
     }
 }


### PR DESCRIPTION
This PR is fixing #3 

It introduces two new workflow parameters that allow configuration of the blob storage's index and 404 documents:

```
index-document: "index.html"
error-document: "404.html"
```

These parameters only apply if `enabled-static-website` is `true`, otherwise they will be ignored.

The PR also fixed a bug where setting `enabled-static-website` to `false` caused an exception. Using a setting of `false` now disables the "static website option" of the storage account as expected.