### PR TITLE
Remove locales from Microsoft Docs URLs in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ With [`Azure Storage Action`](https://github.com/lauchacarro/Azure-Storage-Actio
 * [Setup DotNet](https://github.com/actions/setup-dotnet) Sets up a dotnet environment by optionally downloading and caching a version of dotnet by SDK version and adding to PATH .
   
 ## Create Azure Storage Account and deploy static website using GitHub Actions
-1. Follow the tutorial [Azure Storage Account](https://docs.microsoft.com/learn/modules/create-azure-storage-account/5-exercise-create-a-storage-account))
+1. Follow the tutorial [Azure Storage Account](https://docs.microsoft.com/learn/modules/create-azure-storage-account/5-exercise-create-a-storage-account)
 2. Copy the following example of workflow and create the workflow to `.github/workflows/` in your project repository.
 3. Change `folder` to your folder path where files to deploy are.
 4. Commit and push your project to GitHub repository, you should see a new GitHub Action initiated in **Actions** tab.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ With [`Azure Storage Action`](https://github.com/lauchacarro/Azure-Storage-Actio
 * [Setup DotNet](https://github.com/actions/setup-dotnet) Sets up a dotnet environment by optionally downloading and caching a version of dotnet by SDK version and adding to PATH .
   
 ## Create Azure Storage Account and deploy static website using GitHub Actions
-1. Follow the tutorial [Azure Storage Account](https://docs.microsoft.com/es-es/learn/modules/create-azure-storage-account/5-exercise-create-a-storage-account))
+1. Follow the tutorial [Azure Storage Account](https://docs.microsoft.com/learn/modules/create-azure-storage-account/5-exercise-create-a-storage-account))
 2. Copy the following example of workflow and create the workflow to `.github/workflows/` in your project repository.
 3. Change `folder` to your folder path where files to deploy are.
 4. Commit and push your project to GitHub repository, you should see a new GitHub Action initiated in **Actions** tab.
@@ -51,7 +51,7 @@ For any credentials like Azure Service Principal, Publish Profile, Connection St
 The above example uses the Connection String of your Azure Storage Account.
 
 Follow the steps to configure the secret:
-  * Follow the tutorial [View and copy a connection string](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#view-and-copy-a-connection-string) and copy the connection string.
+  * Follow the tutorial [View and copy a connection string](https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string#view-and-copy-a-connection-string) and copy the connection string.
   * Define a new secret under your repository settings, Add secret menu.
   * Paste the connection string file into the secret's value field.
   * Now in the workflow file in your branch: `.github/workflows/workflow.yml` replace the secret for the input `connection-string:` of the Azure Storage Action (Refer to the example above).


### PR DESCRIPTION
Went to read this readme today and ended up on the Spanish version of the docs page for the Storage Account tutorial. Taking out the locale from the URL will make docs.microsoft automatically pick the most appropriate locale for your web request, so I propose that as the change here.
